### PR TITLE
Improve error messages for missing versions

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -256,11 +256,15 @@ nvm_ensure_version_installed() {
   if [ "_$EXIT_CODE" != "_0" ] || ! nvm_is_version_installed "$LOCAL_VERSION"; then
     VERSION="$(nvm_resolve_alias "$PROVIDED_VERSION")"
     if [ $? -eq 0 ]; then
-      nvm_err "N/A: version \"$PROVIDED_VERSION -> $VERSION\" is not yet installed"
+      nvm_err "N/A: version \"$PROVIDED_VERSION -> $VERSION\" is not yet installed. 
+      
+You need to run \"npm install $PROVIDED_VERSION\" to install it before using it."
     else
       local PREFIXED_VERSION
       PREFIXED_VERSION="$(nvm_ensure_version_prefix "$PROVIDED_VERSION")"
-      nvm_err "N/A: version \"${PREFIXED_VERSION:-$PROVIDED_VERSION}\" is not yet installed"
+      nvm_err "N/A: version \"${PREFIXED_VERSION:-$PROVIDED_VERSION}\" is not yet installed.
+      
+You need to run \"npm install $PROVIDED_VERSION\" to install it before using it."
     fi
     return 1
   fi


### PR DESCRIPTION
`nvm use`, `nvm run` and others check if the version is installed before executing Node, but the error message could be clearer on what steps the user has to take to achieve what they want, this makes that message clearer by telling the user which commands they need to run.